### PR TITLE
Introduce AssetsUtility and ReflectionUtility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ I'm just a hobbyist, so if you have any improvements or suggestions, let me know
 * Serializable Item System (using Scriptable Objects)
 * [Editor scripts](https://github.com/itsschwer/schwer-scripts/tree/master/SchwerScripts/Editor)
     * `PrefabMenu` (menu items to speed up prefab workflow)
+    * `AssetsUtility` (work with assets via code)
     * `ScriptableObjectUtility` (work with Scriptable Object assets via code)
     * TBA
-* TBA
+* TBA (WebGL save/loading!)
 
 # Serializable Item System
 An skeleton implementation of items and inventories using Scriptable Objects.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ I'm just a hobbyist, so if you have any improvements or suggestions, let me know
     * `AssetsUtility` (work with assets via code)
     * `ScriptableObjectUtility` (work with Scriptable Object assets via code)
     * TBA
+* [Common scripts](https://github.com/itsschwer/schwer-scripts/tree/master/SchwerScripts/Common)
+    * `MonoBehaviourSingleton` & `DDOLSingleton`
 * TBA (WebGL save/loading!)
 
 # Serializable Item System

--- a/SchwerScripts/Advanced/ReflectionUtility.cs
+++ b/SchwerScripts/Advanced/ReflectionUtility.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+
+namespace Schwer.Reflection {
+    public static class ReflectionUtility {
+        // Reference: https://stackoverflow.com/questions/12993962/set-value-of-private-field
+        public static void SetPrivateField(object instance, string fieldName, object value) {
+            var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            field.SetValue(instance, value);
+        }
+
+        public static void SetPrivateProperty(object instance, string propertyName, object value) {
+            var prop = instance.GetType().GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Instance);
+            prop.SetValue(instance, value);
+        }
+    }
+}

--- a/SchwerScripts/Common/DDOLSingleton.cs
+++ b/SchwerScripts/Common/DDOLSingleton.cs
@@ -1,0 +1,17 @@
+﻿using UnityEngine;
+
+namespace Schwer {
+    public class DDOLSingleton<T> : MonoBehaviourSingleton<T> where T : MonoBehaviour {
+        protected override void Awake() {
+            if (Instance != null && Instance != this) {
+                // Debug.Log("Instance (" + Instance + ") already set!");
+                Destroy(this.gameObject);
+            }
+            else {
+                Instance = this as T;
+
+                DontDestroyOnLoad(this.gameObject);
+            }
+        }
+    }
+}

--- a/SchwerScripts/Common/MonoBehaviourSingleton.cs
+++ b/SchwerScripts/Common/MonoBehaviourSingleton.cs
@@ -1,0 +1,17 @@
+﻿using UnityEngine;
+
+namespace Schwer {
+    public class MonoBehaviourSingleton<T> : MonoBehaviour where T : MonoBehaviour {
+        public static T Instance { get; protected set; }
+
+        protected virtual void Awake() {
+            if (Instance != null && Instance != this) {
+                // Debug.Log("Instance (" + Instance + ") already set!");
+                Destroy(this.gameObject);
+            }
+            else {
+                Instance = this as T;
+            }
+        }
+    }
+}

--- a/SchwerScripts/Common/README.md
+++ b/SchwerScripts/Common/README.md
@@ -1,0 +1,32 @@
+# schwer-scripts: common
+[![Root](https://img.shields.io/badge/Root-schwer--scripts-blue.svg)](https://github.com/itsschwer/schwer-scripts) [![Donate](https://img.shields.io/badge/Donate-PayPal-brightgreen.svg)](https://www.paypal.com/donate?hosted_button_id=NYFKAS24D4MJS)
+
+A collection of various editor scripts.
+
+## Contents
+* [Singletons (`MonoBehaviourSingleton` & `DDOLSingleton`)](#Singletons)
+
+# Singletons
+Singletons are a useful (but often abused) method of ensuring only one instance of a class exists at any time. Avoid using these where possible.
+
+In a situation where there are multiple instances of a class deriving from these base classes, the longest living one will persist, while any newer ones will `Destroy` themselves (and the game object they are attached to) in `Awake`.
+
+These classes are *not* self-instantiating (i.e. you must make sure an `Instance` exists in the scene before attempting to use it).
+## Base Classes
+* `MonoBehaviourSingleton`
+* `DDOLSingleton`
+#### Example usage:
+```csharp
+public class GameManager : MonoBehaviourSingleton<GameManager> {
+    // ^ If your class needs to be marked as `DontDestroyOnLoad`, inherit from `DDOLSingleton` instead.
+    public int score;
+}
+```
+```csharp
+public class Jewel : MonoBehaviour {
+    private void OnTriggerEnter2D(Collider2D other) {
+        GameManager.Instance.score += 100;
+        Destroy(this.gameObject);
+    }
+}
+```

--- a/SchwerScripts/Editor/AssetsUtility.cs
+++ b/SchwerScripts/Editor/AssetsUtility.cs
@@ -4,6 +4,16 @@ using UnityEngine;
 namespace SchwerEditor {
     public static class AssetsUtility {
         /// <summary>
+        /// Wrapper for `AssetDatabase.SaveAssets`, `AssetDatabase.Refresh`, and `EditorUtility.FocusProjectWindow`.
+        /// </summary>
+        public static void SaveRefreshAndFocus() {
+            //! Need clarification on what each line does.
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            EditorUtility.FocusProjectWindow();
+        }
+        
+        /// <summary>
         /// Returns all assets of a specified type from the Assets folder.
         /// </summary>
         public static T[] GetAllInstances<T>() where T : Object {

--- a/SchwerScripts/Editor/AssetsUtility.cs
+++ b/SchwerScripts/Editor/AssetsUtility.cs
@@ -1,0 +1,22 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace SchwerEditor {
+    public static class AssetsUtility {
+        /// <summary>
+        /// Returns all assets of a specified type from the Assets folder.
+        /// </summary>
+        public static T[] GetAllInstances<T>() where T : Object {
+            // From: https://answers.unity.com/questions/1425758/how-can-i-find-all-instances-of-a-scriptable-objec.html
+            string[] guids = AssetDatabase.FindAssets("t:" + typeof(T).Name);
+
+            T[] instances = new T[guids.Length];
+            for (int i = 0; i < guids.Length; i++) {
+                string path = AssetDatabase.GUIDToAssetPath(guids[i]);
+                instances[i] = AssetDatabase.LoadAssetAtPath<T>(path);
+            }
+
+            return instances;
+        }
+    }
+}

--- a/SchwerScripts/Editor/AssetsUtility.cs
+++ b/SchwerScripts/Editor/AssetsUtility.cs
@@ -16,7 +16,7 @@ namespace SchwerEditor {
         /// <summary>
         /// Returns all assets of a specified type from the Assets folder.
         /// </summary>
-        public static T[] GetAllInstances<T>() where T : Object {
+        public static T[] FindAllInstances<T>() where T : Object {
             // From: https://answers.unity.com/questions/1425758/how-can-i-find-all-instances-of-a-scriptable-objec.html
             string[] guids = AssetDatabase.FindAssets("t:" + typeof(T).Name);
 

--- a/SchwerScripts/Editor/AssetsUtility.cs
+++ b/SchwerScripts/Editor/AssetsUtility.cs
@@ -28,5 +28,20 @@ namespace SchwerEditor {
 
             return instances;
         }
+
+        /// <summary>
+        /// Returns the first asset of a specified type from the Assets folder.
+        /// </summary>
+        public static T FindFirstAsset<T>(string filter) where T : Object {
+            if (!filter.Contains("t:")) {
+                filter = $"{filter} t:{typeof(T)}";
+            }
+
+            var guids = AssetDatabase.FindAssets(filter);
+            if (guids.Length <= 0) return default(T);
+
+            var path = AssetDatabase.GUIDToAssetPath(guids[0]);
+            return AssetDatabase.LoadAssetAtPath(path, typeof(T)) as T;
+        }
     }
 }

--- a/SchwerScripts/Editor/AssetsUtility.cs
+++ b/SchwerScripts/Editor/AssetsUtility.cs
@@ -16,7 +16,7 @@ namespace SchwerEditor {
         /// <summary>
         /// Returns all assets of a specified type from the Assets folder.
         /// </summary>
-        public static T[] FindAllInstances<T>() where T : Object {
+        public static T[] FindAllAssets<T>() where T : Object {
             // From: https://answers.unity.com/questions/1425758/how-can-i-find-all-instances-of-a-scriptable-objec.html
             string[] guids = AssetDatabase.FindAssets("t:" + typeof(T).Name);
 

--- a/SchwerScripts/Editor/AssetsUtility.cs
+++ b/SchwerScripts/Editor/AssetsUtility.cs
@@ -2,6 +2,9 @@
 using UnityEngine;
 
 namespace SchwerEditor {
+    /// <summary>
+    /// Editor class containing wrapper functions for working with assets.
+    /// </summary>
     public static class AssetsUtility {
         /// <summary>
         /// Wrapper for `AssetDatabase.SaveAssets`, `AssetDatabase.Refresh`, and `EditorUtility.FocusProjectWindow`.

--- a/SchwerScripts/Editor/README.md
+++ b/SchwerScripts/Editor/README.md
@@ -7,6 +7,7 @@ These should always be placed in a folder named `Editor`, as that is a [special 
 
 ## Contents
 * [`PrefabMenu`](#PrefabMenu) (menu items to speed up prefab workflow)
+* [`AssetsUtility`](#AssetsUtility) (work with assets via code)
 * [`ScriptableObjectUtility`](#ScriptableObjectUtility) (work with Scriptable Object assets via code)
 * [`EditorWindowUtility`](#EditorWindowUtility) [not yet documented]
 
@@ -24,6 +25,9 @@ public static void InstantiatePlayerPrefab(MenuCommand command) {
     //   and pass that as an argument instead.
 }
 ```
+
+# `AssetsUtility`
+Editor script containing wrapper functions for working with assets.
 
 # `ScriptableObjectUtility`
 Editor script intended for working with Scriptable Object assets through code.

--- a/SchwerScripts/Editor/README.md
+++ b/SchwerScripts/Editor/README.md
@@ -55,6 +55,12 @@ private static List<Item> GetAllItemAssets() {
     return result;
 }
 ```
+### `FindFirstAsset<T>`
+Returns the first asset found of a specified type in the project.
+
+The function will automatically append ` typeof(T)` if the `filter` argument does not contain the `t:` keyword.
+
+Refer to the official Unity documentation on [`AssetDatabase.FindAssets`](https://docs.unity3d.com/ScriptReference/AssetDatabase.FindAssets.html) for more information on the `filter` argument.
 
 # `ScriptableObjectUtility`
 Editor script intended for working with Scriptable Object assets through code.

--- a/SchwerScripts/Editor/README.md
+++ b/SchwerScripts/Editor/README.md
@@ -37,7 +37,7 @@ Returns an array of all assets of a specified type in the project.
 private static List<Item> GetAllItemAssets() {
     var result = new List<Item>();
 
-    var instances = AssetsUtility.FindAllInstances<Item>();
+    var instances = AssetsUtility.FindAllAssets<Item>();
     // ^ Get all instances of type Item for sorting!
     var gatheredIDs = new List<int>();
     for (int i = 0; i < instances.Length; i++) {
@@ -70,7 +70,7 @@ Creates a Scriptable Object of type `T` in a process similar to `[CreateAssetMen
 #### Example usage (from [ItemDatabaseUtility.cs](https://github.com/itsschwer/schwer-scripts/blob/master/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs)):
 ```csharp
 private static ItemDatabase GetItemDatabase() {
-    var databases = AssetsUtility.FindAllInstances<ItemDatabase>();
+    var databases = AssetsUtility.FindAllAssets<ItemDatabase>();
 
     ItemDatabase itemDB = null;
     if (databases.Length < 1) {

--- a/SchwerScripts/Editor/README.md
+++ b/SchwerScripts/Editor/README.md
@@ -28,42 +28,16 @@ public static void InstantiatePlayerPrefab(MenuCommand command) {
 
 # `AssetsUtility`
 Editor script containing wrapper functions for working with assets.
-
-# `ScriptableObjectUtility`
-Editor script intended for working with Scriptable Object assets through code.
 ## Methods
-### `CreateAsset<T>`
-Creates a Scriptable Object of type `T` in a process similar to `[CreateAssetMenu]`. 
-#### Example usage (from [ItemDatabaseUtility.cs](https://github.com/itsschwer/schwer-scripts/blob/master/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs)):
-```csharp
-private static ItemDatabase GetItemDatabase() {
-    var databases = ScriptableObjectUtility.GetAllInstances<ItemDatabase>();
-
-    ItemDatabase itemDB = null;
-    if (databases.Length < 1) {
-        Debug.Log("Creating a new ItemDatabase since none exist.");
-        itemDB = ScriptableObjectUtility.CreateAsset<ItemDatabase>();
-        // ^ Creating an asset if none exist in the project!
-    }
-    else if (databases.Length > 1) {
-        Debug.LogError("Multiple ItemDatabases exist. Please delete the extra(s) and try again.");
-    }
-    else {
-        itemDB = databases[0];
-    }
-
-    return itemDB;
-}
-```
-### `GetAllInstances<T>`
-Returns an array of all Scriptable Object assets of type `T` in the project.
+### `FindAllInstances<T>`
+Returns an array of all assets of a specified type in the project.
 #### Example usage (from [ItemDatabaseUtility.cs](https://github.com/itsschwer/schwer-scripts/blob/master/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs)):
 ```csharp
 // Return a list of Item instances, omitting those with duplicate ids.
 private static List<Item> GetAllItemAssets() {
     var result = new List<Item>();
 
-    var instances = ScriptableObjectUtility.GetAllInstances<Item>();
+    var instances = AssetsUtility.FindAllInstances<Item>();
     // ^ Get all instances of type Item for sorting!
     var gatheredIDs = new List<int>();
     for (int i = 0; i < instances.Length; i++) {
@@ -79,6 +53,33 @@ private static List<Item> GetAllItemAssets() {
 
     result = result.OrderBy(i => i.id).ToList();
     return result;
+}
+```
+
+# `ScriptableObjectUtility`
+Editor script intended for working with Scriptable Object assets through code.
+## Methods
+### `CreateAsset<T>`
+Creates a Scriptable Object of type `T` in a process similar to `[CreateAssetMenu]`. 
+#### Example usage (from [ItemDatabaseUtility.cs](https://github.com/itsschwer/schwer-scripts/blob/master/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs)):
+```csharp
+private static ItemDatabase GetItemDatabase() {
+    var databases = AssetsUtility.FindAllInstances<ItemDatabase>();
+
+    ItemDatabase itemDB = null;
+    if (databases.Length < 1) {
+        Debug.Log("Creating a new ItemDatabase since none exist.");
+        itemDB = ScriptableObjectUtility.CreateAsset<ItemDatabase>();
+        // ^ Creating an asset if none exist in the project!
+    }
+    else if (databases.Length > 1) {
+        Debug.LogError("Multiple ItemDatabases exist. Please delete the extra(s) and try again.");
+    }
+    else {
+        itemDB = databases[0];
+    }
+
+    return itemDB;
 }
 ```
 

--- a/SchwerScripts/Editor/ScriptableObjectUtility.cs
+++ b/SchwerScripts/Editor/ScriptableObjectUtility.cs
@@ -3,6 +3,9 @@ using UnityEditor;
 using UnityEngine;
 
 namespace SchwerEditor {
+    /// <summary>
+    /// Editor class for working with Scriptable Object assets.
+    /// </summary>
     public static class ScriptableObjectUtility {
         /// <summary>
         /// Creates a new Scriptable Object asset in a manner that mimics Unity's asset creation process.

--- a/SchwerScripts/Editor/ScriptableObjectUtility.cs
+++ b/SchwerScripts/Editor/ScriptableObjectUtility.cs
@@ -5,16 +5,6 @@ using UnityEngine;
 namespace SchwerEditor {
     public static class ScriptableObjectUtility {
         /// <summary>
-        /// Wrapper for `AssetDatabase.SaveAssets`, `AssetDatabase.Refresh`, and `EditorUtility.FocusProjectWindow`.
-        /// </summary>
-        public static void SaveRefreshAndFocus() {
-            //! Need clarification on what each line does.
-            AssetDatabase.SaveAssets();
-            AssetDatabase.Refresh();
-            EditorUtility.FocusProjectWindow();
-        }
-
-        /// <summary>
         /// Creates a new Scriptable Object asset in a manner that mimics Unity's asset creation process.
         /// </summary>
         public static T CreateAsset<T>() where T : ScriptableObject {
@@ -31,7 +21,7 @@ namespace SchwerEditor {
             path = AssetDatabase.GenerateUniqueAssetPath(path + "/" + typeof(T).Name + ".asset");
             
             AssetDatabase.CreateAsset(asset, path);
-            SaveRefreshAndFocus();
+            AssetsUtility.SaveRefreshAndFocus();
             return asset;
         }
     }

--- a/SchwerScripts/Editor/ScriptableObjectUtility.cs
+++ b/SchwerScripts/Editor/ScriptableObjectUtility.cs
@@ -34,21 +34,5 @@ namespace SchwerEditor {
             SaveRefreshAndFocus();
             return asset;
         }
-
-        /// <summary>
-        /// Get all instances of a specified Scriptable Object from the Assets folder.
-        /// </summary>
-        public static T[] GetAllInstances<T>() where T: ScriptableObject {
-            // From: https://answers.unity.com/questions/1425758/how-can-i-find-all-instances-of-a-scriptable-objec.html
-            string[] guids = AssetDatabase.FindAssets("t:" + typeof(T).Name);
-
-            T[] instances = new T[guids.Length];
-            for (int i = 0; i < guids.Length; i++) {
-                string path = AssetDatabase.GUIDToAssetPath(guids[i]);
-                instances[i] = AssetDatabase.LoadAssetAtPath<T>(path);
-            }
-
-            return instances;
-        }
     }
 }

--- a/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs
+++ b/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs
@@ -45,7 +45,7 @@ namespace SchwerEditor.ItemSystem {
         }
 
         private static ItemDatabase GetItemDatabase() {
-            var databases = AssetsUtility.FindAllInstances<ItemDatabase>();
+            var databases = AssetsUtility.FindAllAssets<ItemDatabase>();
 
             ItemDatabase itemDB = null;
             if (databases.Length < 1) {
@@ -65,7 +65,7 @@ namespace SchwerEditor.ItemSystem {
         private static List<Item> GetAllItemAssets() {
             var result = new List<Item>();
 
-            var instances = AssetsUtility.FindAllInstances<Item>();
+            var instances = AssetsUtility.FindAllAssets<Item>();
             var gatheredIDs = new List<int>();
             for (int i = 0; i < instances.Length; i++) {
                 if (gatheredIDs.Contains(instances[i].id)) {

--- a/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs
+++ b/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs
@@ -40,7 +40,7 @@ namespace SchwerEditor.ItemSystem {
             itemDB.Initialise(GetAllItemAssets());
             EditorUtility.SetDirty(itemDB);
 
-            ScriptableObjectUtility.SaveRefreshAndFocus();
+            AssetsUtility.SaveRefreshAndFocus();
             Selection.activeObject = itemDB;
         }
 

--- a/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs
+++ b/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs
@@ -45,7 +45,7 @@ namespace SchwerEditor.ItemSystem {
         }
 
         private static ItemDatabase GetItemDatabase() {
-            var databases = ScriptableObjectUtility.GetAllInstances<ItemDatabase>();
+            var databases = AssetsUtility.GetAllInstances<ItemDatabase>();
 
             ItemDatabase itemDB = null;
             if (databases.Length < 1) {
@@ -65,7 +65,7 @@ namespace SchwerEditor.ItemSystem {
         private static List<Item> GetAllItemAssets() {
             var result = new List<Item>();
 
-            var instances = ScriptableObjectUtility.GetAllInstances<Item>();
+            var instances = AssetsUtility.GetAllInstances<Item>();
             var gatheredIDs = new List<int>();
             for (int i = 0; i < instances.Length; i++) {
                 if (gatheredIDs.Contains(instances[i].id)) {

--- a/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs
+++ b/SchwerScripts/ItemSystem/Editor/ItemDatabaseUtility.cs
@@ -45,7 +45,7 @@ namespace SchwerEditor.ItemSystem {
         }
 
         private static ItemDatabase GetItemDatabase() {
-            var databases = AssetsUtility.GetAllInstances<ItemDatabase>();
+            var databases = AssetsUtility.FindAllInstances<ItemDatabase>();
 
             ItemDatabase itemDB = null;
             if (databases.Length < 1) {
@@ -65,7 +65,7 @@ namespace SchwerEditor.ItemSystem {
         private static List<Item> GetAllItemAssets() {
             var result = new List<Item>();
 
-            var instances = AssetsUtility.GetAllInstances<Item>();
+            var instances = AssetsUtility.FindAllInstances<Item>();
             var gatheredIDs = new List<int>();
             for (int i = 0; i < instances.Length; i++) {
                 if (gatheredIDs.Contains(instances[i].id)) {

--- a/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
+++ b/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
@@ -51,7 +51,7 @@ namespace SchwerEditor.ItemSystem {
         // Also see this: https://stackoverflow.com/questions/56298821/balancing-calls-inside-of-a-editorwindow-ongui-method-causing-problems
         private void Update() {
             //! Should probably only run this line if an Item asset was created or deleted.
-            itemAssets = AssetsUtility.GetAllInstances<Item>().OrderBy(i => i.id).ToArray();
+            itemAssets = AssetsUtility.FindAllInstances<Item>().OrderBy(i => i.id).ToArray();
 
             Repaint();
         }

--- a/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
+++ b/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
@@ -51,7 +51,7 @@ namespace SchwerEditor.ItemSystem {
         // Also see this: https://stackoverflow.com/questions/56298821/balancing-calls-inside-of-a-editorwindow-ongui-method-causing-problems
         private void Update() {
             //! Should probably only run this line if an Item asset was created or deleted.
-            itemAssets = AssetsUtility.FindAllInstances<Item>().OrderBy(i => i.id).ToArray();
+            itemAssets = AssetsUtility.FindAllAssets<Item>().OrderBy(i => i.id).ToArray();
 
             Repaint();
         }

--- a/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
+++ b/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
@@ -51,7 +51,7 @@ namespace SchwerEditor.ItemSystem {
         // Also see this: https://stackoverflow.com/questions/56298821/balancing-calls-inside-of-a-editorwindow-ongui-method-causing-problems
         private void Update() {
             //! Should probably only run this line if an Item asset was created or deleted.
-            itemAssets = ScriptableObjectUtility.GetAllInstances<Item>().OrderBy(i => i.id).ToArray();
+            itemAssets = AssetsUtility.GetAllInstances<Item>().OrderBy(i => i.id).ToArray();
 
             Repaint();
         }


### PR DESCRIPTION
## `ScriptableObjectUtility`
- Now only contains `CreateAsset<T>`.
## `AssetsUtility` (new class)
-  `SaveRefreshAndFocus` moved from `ScriptableObjectUtility`.
- `FindAllAssets<T>` moved from `ScriptableObjectUtility` (previously named `GetAllInstances<T>`).
- New method `FindFirstAsset<T>` as a wrapper for getting a reference to the first found asset of a specified type.
## `ReflectionUtility` (new class)
- Contains methods for assigning to private fields/properties.
- Intended only for editor scripting, but is available under the `Schwer.Reflection` namespace.
## Singleton base classes
- Added `MonoBehaviourSingleton`
- Added `DDOLSingleton`
- Refer to readme for details.
## Readmes
- Mostly updated to reflect changes and additions.