### PR TITLE
Fix AssetsUtility.FindAllAssets to use the specified type's fully qualified name

### DIFF
--- a/SchwerScripts/Editor/AssetsUtility.cs
+++ b/SchwerScripts/Editor/AssetsUtility.cs
@@ -21,9 +21,9 @@ namespace SchwerEditor {
         /// </summary>
         public static T[] FindAllAssets<T>() where T : Object {
             // From: https://answers.unity.com/questions/1425758/how-can-i-find-all-instances-of-a-scriptable-objec.html
-            string[] guids = AssetDatabase.FindAssets("t:" + typeof(T).FullName);
+            var guids = AssetDatabase.FindAssets("t:" + typeof(T).FullName);
 
-            T[] instances = new T[guids.Length];
+            var instances = new T[guids.Length];
             for (int i = 0; i < guids.Length; i++) {
                 string path = AssetDatabase.GUIDToAssetPath(guids[i]);
                 instances[i] = AssetDatabase.LoadAssetAtPath<T>(path);

--- a/SchwerScripts/Editor/AssetsUtility.cs
+++ b/SchwerScripts/Editor/AssetsUtility.cs
@@ -21,7 +21,7 @@ namespace SchwerEditor {
         /// </summary>
         public static T[] FindAllAssets<T>() where T : Object {
             // From: https://answers.unity.com/questions/1425758/how-can-i-find-all-instances-of-a-scriptable-objec.html
-            var guids = AssetDatabase.FindAssets("t:" + typeof(T).FullName);
+            var guids = AssetDatabase.FindAssets($"t:{typeof(T)}");
 
             var instances = new T[guids.Length];
             for (int i = 0; i < guids.Length; i++) {

--- a/SchwerScripts/Editor/AssetsUtility.cs
+++ b/SchwerScripts/Editor/AssetsUtility.cs
@@ -21,7 +21,7 @@ namespace SchwerEditor {
         /// </summary>
         public static T[] FindAllAssets<T>() where T : Object {
             // From: https://answers.unity.com/questions/1425758/how-can-i-find-all-instances-of-a-scriptable-objec.html
-            string[] guids = AssetDatabase.FindAssets("t:" + typeof(T).Name);
+            string[] guids = AssetDatabase.FindAssets("t:" + typeof(T).FullName);
 
             T[] instances = new T[guids.Length];
             for (int i = 0; i < guids.Length; i++) {


### PR DESCRIPTION
Fixes issues that may arise when using the method in a project where there are classes that share the same name *(e.g. `Schwer.ItemSystem.Item` and `Item`)*.